### PR TITLE
Allow HTTPS scheme

### DIFF
--- a/restnavigator/utils.py
+++ b/restnavigator/utils.py
@@ -17,11 +17,12 @@ def fix_scheme(url):
     other than http is used'''
     splitted = url.split('://')
     if len(splitted) == 2:
-        if splitted[0] == 'http':
+        if splitted[0] in ('http', 'https'):
             return url
         else:
             raise exc.WileECoyoteException(
-                'Bad scheme! Got: {}, expected http'.format(splitted[0]))
+                'Bad scheme! Got: {}, expected http or https'.format(
+                    splitted[0]))
     elif len(splitted) == 1:
         return 'http://' + url
     else:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,6 +26,8 @@ def blank(request):
 
 def test_fix_scheme():
     assert RNU.fix_scheme('http://www.example.com') == 'http://www.example.com'
+    assert RNU.fix_scheme('https://www.example.com') == \
+        'https://www.example.com'
     assert RNU.fix_scheme('www.example.com') == 'http://www.example.com'
     with pytest.raises(ValueError):
         RNU.fix_scheme('ftp://www.example.com')


### PR DESCRIPTION
The `fix_scheme` function only allowed HTTP connections to the URL root, preventing you from connecting via HTTPS.
