### PR TITLE
Enhancement (DELETE) and Bug fixes (around POST response)

### DIFF
--- a/restnavigator/constants.py
+++ b/restnavigator/constants.py
@@ -1,9 +1,0 @@
-import httplib
-
-GET = 'get'
-POST = 'post'
-DELETE = 'delete'
-
-POSITIVE_STATUS_CODES  = {
-    DELETE: (httplib.ACCEPTED,httplib.NO_CONTENT,httplib.SEE_OTHER,httplib.OK ),
-    POST: (httplib.CREATED, httplib.ACCEPTED,httplib.FOUND,httplib.SEE_OTHER,httplib.OK)}

--- a/restnavigator/constants.py
+++ b/restnavigator/constants.py
@@ -1,0 +1,9 @@
+import httplib
+
+GET = 'get'
+POST = 'post'
+DELETE = 'delete'
+
+POSITIVE_STATUS_CODES  = {
+    DELETE: (httplib.ACCEPTED,httplib.NO_CONTENT,httplib.SEE_OTHER,httplib.OK ),
+    POST: (httplib.CREATED, httplib.ACCEPTED,httplib.FOUND,httplib.SEE_OTHER,httplib.OK)}

--- a/restnavigator/halnav.py
+++ b/restnavigator/halnav.py
@@ -191,6 +191,8 @@ class HALNavigator(object):
              for rel, links in body.get('_links', {}).iteritems()
              if rel not in ['self', 'curies']})
 
+
+
     @template_uri_check
     def fetch(self, raise_exc=True):
         '''Like __call__, but doesn't cache, always makes the request'''
@@ -264,7 +266,10 @@ class HALNavigator(object):
                             json_cls=None,
                             headers=None,
     ):
-
+        '''
+            Fetches HTTP response using http method (POST or DELETE of requests.Session)
+            Raises HALNavigatorError if response is not positive
+        '''
         if isinstance(body, dict):
             body = json.dumps(body, cls=json_cls, separators=(',', ':'))
         headers = {} if headers is None else headers
@@ -278,6 +283,7 @@ class HALNavigator(object):
                 nav=self,
                 response=response,
             )
+        return response
 
     @template_uri_check
     def post(self,
@@ -309,10 +315,9 @@ class HALNavigator(object):
                                     httplib.SEE_OTHER,
         ) and 'Location' in response.headers:
             return self._copy(uri=response.headers['Location'])
-
-        if response.status_code == httplib.OK:
-            # Expected only httplib.OK which has some description
-            #Else we might be catching errored response
+        else:
+            # response.status_code  in [httplib.OK, httplib.NO_CONTENT]
+            # Expected only httplib.OK has some description
             return HALResponse(parent=self, response=response)
 
     create = post

--- a/restnavigator/halnav.py
+++ b/restnavigator/halnav.py
@@ -104,6 +104,7 @@ class HALNavigator(object):
         self.template_args = None
         self.parameters = None
         self.templated = False
+        self.method = 'GET'
         self._links = None
         # This is the identity map shared by all descendents of this
         # HALNavigator
@@ -336,7 +337,7 @@ class HALNavigator(object):
         `json_cls` is a JSONEncoder to use rather than the standard
         `headers` are additional headers to send in the request'''
 
-        response = self.get_http_response( self.session.post,
+        response = self.get_http_response( self.session.delete,
                                             body,
                                             raise_exc,
                                             content_type,
@@ -344,6 +345,11 @@ class HALNavigator(object):
                                             headers,
         )
 
+        if response.status_code in (httplib.ACCEPTED,
+                                    httplib.FOUND,
+                                    httplib.SEE_OTHER,
+        ) and 'Location' in response.headers:
+            return self._copy(uri=response.headers['Location'])
         if response.status_code == httplib.OK:
             ''' Only status code, returns some description '''
             return HALResponse(parent=self, response=response)

--- a/restnavigator/halnav.py
+++ b/restnavigator/halnav.py
@@ -413,7 +413,8 @@ class PostResponse(HALNavigator):
             'Maybe you want this object\'s .parent attribute, '
             'or possibly one of the resources in .links')
 
-    __call__ = fetch
+    def __call__(self, *args, **kwargs):
+        return self.state.copy()
 
     def create(self, *args, **kwargs):
         raise NotImplementedError(

--- a/restnavigator/halnav.py
+++ b/restnavigator/halnav.py
@@ -30,7 +30,7 @@ def autofetch(fn):
     @functools.wraps(fn)
     def wrapped(self, *args, **qargs):
         if self.idempotent and self.response is None:
-            self.fetch(raise_exc=qargs.get('raise_exc', False))
+            self.fetch(raise_exc=qargs.get('raise_exc', False), strict=qargs.get('strict',True))
         return fn(self, *args, **qargs)
 
     return wrapped
@@ -62,21 +62,6 @@ def template_uri_check(fn):
         return fn(self, *args, **qargs)
 
     return wrapped
-
-def method_validation(allowed_list):
-    def wrap(f):
-        def wrapped(self,*args, **qargs):
-            if qargs['strict'] and self.method.upper() not in allowed_list:
-                raise HALNavigatorError(u'{} is possible for resources with methods {}.'
-                                        u'{} is the only allowed methods for {}'.format(f.__name__,
-                                                                                        allowed_list,
-                                                                                        self.method,
-                                                                                        self.uri),
-                                        nav=self,
-                )
-            f(self, *args, **qargs)
-        return wrapped
-    return wrap
 
 class HALNavigator(object):
     '''The main navigation entity'''
@@ -192,6 +177,7 @@ class HALNavigator(object):
                 title=link.get('title'),
                 type=link.get('type'),
                 profile=link.get('profile'),
+                method=link.get('method')
             )
             if templated:
                 cp.uri = None
@@ -209,9 +195,12 @@ class HALNavigator(object):
 
 
     @template_uri_check
-    @method_validation(allowed_list=['GET'])
+    #@method_validation(allowed_list=['GET'])
     def fetch(self, raise_exc=True, strict=True):
         '''Like __call__, but doesn't cache, always makes the request'''
+        if self.method != 'GET' and strict==True:
+            raise HALNavigatorError('{} supports only {}, not GET'.format(self, self.method))
+
         self.response = self.session.get(self.uri)
 
         try:
@@ -269,9 +258,9 @@ class HALNavigator(object):
     def __ne__(self, other):
         return not self == other
 
-    def __call__(self, raise_exc=True, strict=True):
+    def __call__(self, raise_exc=True):
         if self.response is None:
-            return self.fetch(raise_exc=raise_exc, strict=strict)
+            return self.fetch(raise_exc=raise_exc)
         else:
             return self.state.copy()
 
@@ -282,11 +271,18 @@ class HALNavigator(object):
                             content_type='application/json',
                             json_cls=None,
                             headers=None,
+                            strict=True
     ):
         '''
             Fetches HTTP response using http method (POST or DELETE of requests.Session)
             Raises HALNavigatorError if response is not positive
         '''
+
+        http_method  = http_method_fn.__name__.upper()
+
+        if self.method != http_method and strict==True:
+            raise HALNavigatorError(u'{} supports only {}, not {}'.format(self.uri, self.method, http_method))
+
         if isinstance(body, dict):
             body = json.dumps(body, cls=json_cls, separators=(',', ':'))
         headers = {} if headers is None else headers
@@ -303,7 +299,7 @@ class HALNavigator(object):
         return response
 
     @template_uri_check
-    @method_validation(allowed_list=['POST'])
+    #@method_validation(allowed_list=['POST'])
     def post(self,
              body,
              raise_exc=True,
@@ -341,7 +337,7 @@ class HALNavigator(object):
     create = post
 
     @template_uri_check
-    @method_validation(allowed_list=['DELETE'])
+    #@method_validation(allowed_list=['DELETE'])
     def delete(self,
                body=None,
                raise_exc=True,

--- a/tests/test_hal_nav.py
+++ b/tests/test_hal_nav.py
@@ -623,9 +623,9 @@ def test_PostResponse__basic(status, body, content_type):
 
         N = HN.HALNavigator(index_uri)
         N2 = N['hosts']
-        PR = N2.create({})  # PR = PostResponse
+        PR = N2.create({})  # PR = HALResponse
 
-        assert isinstance(PR, HN.PostResponse)
+        assert isinstance(PR, HN.HALResponse)
         assert PR.status[0] == status
         assert PR.parent is N2
 

--- a/tests/test_hal_nav.py
+++ b/tests/test_hal_nav.py
@@ -1,17 +1,17 @@
 from __future__ import print_function
 
-import httpretty
 import json
-import pytest
 import re
 import contextlib
 import random
 import string
 
+import httpretty
+import pytest
 import uritemplate
-import requests.auth
 
 import restnavigator.halnav as HN
+
 
 # pylint: disable-msg=E1101
 
@@ -21,6 +21,7 @@ def random_string():
     def rs():
         while True:
             yield ''.join(random.sample(string.ascii_letters, 6))
+
     return rs()
 
 
@@ -45,7 +46,7 @@ def register_hal(uri='http://www.example.com/',
                  method='GET',
                  headers=None,
                  status=200,
-                 ):
+):
     '''Convenience function that registers a hal document at a given address'''
 
     def body_callback(_meth, req_uri, req_headers):
@@ -118,10 +119,10 @@ def test_HALNAvigator__repr():
         assert repr(N) == "HALNavigator(exampleAPI)"
         assert repr(N['first']) == "HALNavigator(exampleAPI.first)"
         assert repr(N['next']) == \
-            "HALNavigator(exampleAPI.foos.123f.bars[234])"
+               "HALNavigator(exampleAPI.foos.123f.bars[234])"
         assert repr(N['last']) == "HALNavigator(exampleAPI.last)"
         assert repr(N['describes']) == \
-          "HALNavigator(exampleAPI.users.kozuscek)"
+               "HALNavigator(exampleAPI.users.kozuscek)"
 
 
 def test_HALNavigator__links():
@@ -129,7 +130,7 @@ def test_HALNavigator__links():
         register_hal('http://www.example.com/',
                      links={'ht:users': {
                          'href': 'http://www.example.com/users'}}
-                     )
+        )
         N = HN.HALNavigator('http://www.example.com')
         expected = {
             'ht:users': HN.HALNavigator('http://www.example.com')['ht:users']
@@ -308,7 +309,7 @@ def test_HALNavigator__getitem_gauntlet():
         assert expanded_nav.uri == uritemplate.expand(template_href,
                                                       {'max': 1, 'page': '0'})
         assert N['first'].expand(page=0, max=1) == expanded_nav
-        assert N['first']['page': 0].uri == uritemplate\
+        assert N['first']['page': 0].uri == uritemplate \
             .expand(template_href, {'page': '0'})
         assert N['first', :].uri == uritemplate.expand(
             template_href, variables={})
@@ -587,7 +588,7 @@ def test_HALNavigator__create(redirect_status, post_body):
                                uri=hosts_uri,
                                location=new_resource_uri,
                                status=redirect_status,
-                               )
+        )
         N = HN.HALNavigator(index_uri)
         N2 = N['hosts'].create(post_body)
         assert HTTPretty.last_request.method == 'POST'
@@ -597,12 +598,13 @@ def test_HALNavigator__create(redirect_status, post_body):
         assert N2.uri == new_resource_uri
         assert not N2.fetched
 
+
 @pytest.mark.parametrize(('status', 'body', 'content_type'), [
     (200, 'hi there', 'text/plain'),
     (200, '{"hi": "there"}', 'application/json'),
     (200,
-     json.dumps({'_links': {'alternate': {'href': '/hogo'}}}),
-     'application/hal+json'),
+     json.dumps({'_links': {'alternate': {'href': '/hogo'}},
+                 "hi": "there"}), 'application/hal+json'),
     (204, '', 'text/plain'),
 ])
 def test_PostResponse__basic(status, body, content_type):
@@ -626,8 +628,7 @@ def test_PostResponse__basic(status, body, content_type):
         assert isinstance(PR, HN.PostResponse)
         assert PR.status[0] == status
         assert PR.parent is N2
-        with pytest.raises(NotImplementedError):
-            PR()
+
         with pytest.raises(NotImplementedError):
             PR.fetch()
         with pytest.raises(NotImplementedError):
@@ -644,6 +645,8 @@ def test_PostResponse__basic(status, body, content_type):
             assert PR.state == {}
             assert PR.links == {}
 
+        assert PR() == PR.state
+
 
 def test_HALNavigator__relative_links():
     with httprettify():
@@ -659,7 +662,7 @@ def test_HALNavigator__relative_links():
         N = HN.HALNavigator(index_uri)
         assert N['about'].uri == 'http://www.example.com/about/'
         assert N['about', 'alternate'].uri == \
-            'http://www.example.com/about/alternate'
+               'http://www.example.com/about/alternate'
         assert N['about']['index'].uri == 'http://www.example.com/about/index'
 
 
@@ -678,6 +681,7 @@ def test_HALNavigator__authenticate(random_string):
                 return (200, headers, json.dumps({'authenticated': True}))
             else:
                 return (401, headers, json.dumps({'authenticated': False}))
+
         register_hal(index_uri, index_links)
         HTTPretty.register_uri('GET', auth_uri, body=auth_callback)
 
@@ -719,6 +723,7 @@ def test_HALNavigator__custom_headers():
         N()
         assert HTTPretty.last_request.headers.get('X-Pizza')
 
+
 @pytest.fixture
 def bigtest_1():
     bigtest = type(str('bigtest_1'), (object,), {})
@@ -734,20 +739,21 @@ def bigtest_1():
              'name': 'bar',
              'title': 'Bar',
              'profile': widget,
-             },
+            },
             {'href': index_uri + 'baz',
              'name': 'baz',
              'title': 'Baz',
              'profile': gadget,
-             },
+            },
             {'href': index_uri + 'qux',
              'name': 'qux',
              'title': 'Qux',
              'profile': widget,
-             },
+            },
         ]
     }
     return bigtest
+
 
 def test_HALNavigator__get_by_properties_single(bigtest_1):
     with httprettify() as HTTPretty:
@@ -762,6 +768,7 @@ def test_HALNavigator__get_by_properties_single(bigtest_1):
         assert bar.uri == bigtest_1.index_links['test:foo'][0]['href']
         assert qux.uri == bigtest_1.index_links['test:foo'][2]['href']
         assert not_found is None
+
 
 def test_HALNavigator__get_by_properties_multi(bigtest_1):
     with httprettify() as HTTPretty:
@@ -784,7 +791,6 @@ def test_HALNavigator__get_by_properties_multi(bigtest_1):
         assert gadgets == [baz]
 
 
-
 @pytest.fixture
 def reltest_links():
     return {
@@ -802,6 +808,7 @@ def reltest_links():
         },
     }
 
+
 def test_HALNavigator__default_curie_noconflict(reltest_links):
     with httprettify() as HTTPretty:
         index_uri = "http://example.com/api"
@@ -813,6 +820,7 @@ def test_HALNavigator__default_curie_noconflict(reltest_links):
         N2 = N['xx:nonstandard-rel']
 
         assert N1 is N2
+
 
 def test_HALNavigator__default_curie_conflict(reltest_links):
     with httprettify() as HTTPretty:
@@ -829,6 +837,7 @@ def test_HALNavigator__default_curie_conflict(reltest_links):
 
         assert N2.uri == 'http://example.com/api/xxnext'
 
+
 def test_HALNavigator__default_curie_wrong_curie(reltest_links):
     with httprettify() as HTTPretty:
         index_uri = "http://example.com/api"
@@ -840,6 +849,7 @@ def test_HALNavigator__default_curie_wrong_curie(reltest_links):
         N2 = N['yy:nonstandard-rel']
 
         assert N1 is not N2
+
 
 def test_HALNavigator__default_curie_iana_conflict(reltest_links):
     with httprettify() as HTTPretty:

--- a/tests/test_hal_nav.py
+++ b/tests/test_hal_nav.py
@@ -13,6 +13,7 @@ import uritemplate
 import restnavigator.halnav as HN
 
 
+
 # pylint: disable-msg=E1101
 
 
@@ -581,7 +582,7 @@ def test_HALNavigator__create(redirect_status, post_body):
         index_uri = 'http://www.example.com/api/'
         hosts_uri = index_uri + 'hosts'
         new_resource_uri = index_uri + 'new_resource'
-        index_links = {'hosts': {'href': hosts_uri}}
+        index_links = {'hosts': {'href': hosts_uri, 'method': 'POST'}}
         register_hal(index_uri, index_links)
         register_hal(new_resource_uri)
         HTTPretty.register_uri('POST',
@@ -610,7 +611,7 @@ def test_HALNavigator__delete(redirect_status, delete_body):
         index_uri = 'http://www.example.com/api/'
         hosts_uri = index_uri + 'hosts'
         new_resource_uri = index_uri + 'new_resource'
-        index_links = {'hosts': {'href': hosts_uri}}
+        index_links = {'hosts': {'href': hosts_uri, 'method': 'DELETE'}}
         register_hal(index_uri, index_links)
         register_hal(new_resource_uri)
         HTTPretty.register_uri('DELETE',
@@ -628,7 +629,6 @@ def test_HALNavigator__delete(redirect_status, delete_body):
         assert not N2.fetched
 
 
-
 @pytest.mark.parametrize(('status', 'body', 'content_type'), [
     (200, 'hi there', 'text/plain'),
     (200, '{"hi": "there"}', 'application/json'),
@@ -641,7 +641,7 @@ def test_HALResponse__basic(status, body, content_type):
     with httprettify() as HTTPretty:
         index_uri = 'http://www.example.com/api/'
         hosts_uri = index_uri + 'hosts'
-        index_links = {'hosts': {'href': hosts_uri}}
+        index_links = {'hosts': {'href': hosts_uri, 'method': 'POST'}}
         register_hal(index_uri, index_links)
         HTTPretty.register_uri(
             'POST',


### PR DESCRIPTION
1. In fetch(), the check for negative response to raise HALNavigatorError,
      if raise_exc and not self.response:
           raise HALNavigatorError(self.response.text,
                                   status=self.status,
                                   nav=self,
                                   response=self.response,
           )  
   Is not too late in the flow?. I feel it should be checked before processing the response body 
2. PostResponse can have properties, hence implemented **call** to return properties
3. DELETE method is similar to POST from Navigator perspective (non-idempotent) 
   Hence,
          a) Reused logic from POST to implement support for DELETE
          b) renamed PostResponse to HALResponse 
          c) renamed  create() to post() for clarity
   In order to provide backward compatibility, I created alias "create"  to "post"
4. HALNavigator should not allow POST if the uri is templated. The check for templated_uri 
   was missing. Created a wrapper function (@template_uri_check) to re-use for all methods - GET/POST/DELETE

TODO:
1. Enforce templated_uri check for all HTTP calls. Add test coverage 
2. a link usually have 'method' property (default to 'GET'), which can be used to restrict http operations. this helps to raise NotImplementedError and can have a controlled default function e.g autofetch
