### PR TITLE
Include 'self' in the list of returned links

### DIFF
--- a/restnavigator/halnav.py
+++ b/restnavigator/halnav.py
@@ -340,7 +340,7 @@ class HALNavigatorBase(object):
         '''Creates linked navigators from a HAL response body'''
         ld = utils.LinkDict(self._core.default_curie, {})
         for rel, link in body.get('_links', {}).items():
-            if rel not in ['self', 'curies']:
+            if rel != 'curies':
                 if isinstance(link, list):
                     ld[rel] = utils.LinkList(
                         (self._navigator_or_thunk(lnk), lnk) for lnk in link)

--- a/tests/test_hal_nav.py
+++ b/tests/test_hal_nav.py
@@ -135,6 +135,7 @@ def test_HALNavigator__links():
         )
         N = HN.Navigator.hal('http://www.example.com')
         expected = {
+            'self': HN.Navigator.hal('http://www.example.com')['self'],
             'ht:users': HN.Navigator.hal('http://www.example.com')['ht:users']
         }
         assert N.links() == expected


### PR DESCRIPTION
For testing a web application, I need to be able to verify the existence of the 'self' link.

The uri of the self link is stored as the uri of the HALNavigator object. But for testing link availability it should also be included in the list of links. Is there any reason not to include it?

I note that in '_update_self_link' you never update the uri of the HALNavigator object (guess that would break the APICore caching...?) but that does mean that if the 'self' link changes during the lifetime of a resource, then the HALNavigator uri would be out of synch. On the other hand, I'm not sure what would be the correct thing to do in this case.
