### PR TITLE
Amend _create_navigator to store the response for POST, PUSH, PATCH etc.

### DIFF
--- a/restnavigator/halnav.py
+++ b/restnavigator/halnav.py
@@ -241,7 +241,7 @@ class HALNavigatorBase(object):
 
     @property
     def fetched(self):
-        return self.response is not None
+        return self.state is not None
 
     def __repr__(self):  # pragma: nocover
         relative_uri = self.self.relative_uri(self._core.root)
@@ -425,7 +425,7 @@ class HALNavigator(HALNavigatorBase):
     '''The main navigation entity'''
 
     def __call__(self, raise_exc=True):
-        if self.response is None:
+        if not self.fetched:
             return self.fetch(raise_exc=raise_exc)
         else:
             return self.state.copy()
@@ -446,7 +446,9 @@ class HALNavigator(HALNavigatorBase):
                 core=self._core
             )
             # We don't ingest the response because we haven't fetched
-            # the newly created resource yet
+            # the newly created resource yet,
+            # but we do store the response
+            nav.response = response
         elif method in (POST, PUT, PATCH, DELETE):
             nav = OrphanHALNavigator(
                 link=None,


### PR DESCRIPTION
Storing the response on a POST, PUSH, PATCH allows the HALNavigator-based client application to query or log the response. However, it breaks the current logic for the 'fetched' property, which checks for the existence of a response.

It seems more correct for the 'fetched' property to check for the existence of a resource state dictionary, which is only created when a response is successfully parsed and ingested.
