### PR TITLE
Smarter parsing of content type

### DIFF
--- a/restnavigator/utils.py
+++ b/restnavigator/utils.py
@@ -166,6 +166,15 @@ def objectify_uri(relative_uri):
     nice_uri = unidecode.unidecode(unquoted)
     return ''.join(path_clean(c) for c in nice_uri.split('/'))
 
+    
+def parse_media_type(media_type):
+    '''Returns type, subtype, parameter tuple from an http media_type.
+    Can be applied to the 'Accept' or 'Content-Type' http header fields.
+    '''
+    media_type, sep, parameter = str(media_type).partition(';')
+    media_type, sep, subtype = media_type.partition('/')
+    return tuple(x.strip() or None for x in (media_type, subtype, parameter))
+
 
 class LinkList(list):
     '''A list subclass that offers different ways of grabbing the values based

--- a/tests/test_hal_nav.py
+++ b/tests/test_hal_nav.py
@@ -612,6 +612,39 @@ def test_HALNavigator__custom_headers():
         assert HTTPretty.last_request.headers.get('X-Pizza')
 
 
+@pytest.mark.parametrize(('accept', 'content_type', 'can_parse'), [
+    ('application/json', 'application/json', True),
+    ('application/json', 'foo', False),
+    ('application/hal+json,application/json', 'application/json', True),
+    ('application/hal+json,application/json', 'application/hal+json', True),
+    # optimistically accept content_type with additional parameter
+    ('application/hal+json,application/json', 'application/hal+json; charset=utf-8', True),
+    ('application/hal+json,application/json; charset=utf-8', 'application/hal+json', True),
+    # optimistically accept content_type with missing parameter
+    ('application/hal+json,application/json;charset=utf-8', 'application/json', True),
+    ('application/hal+json,application/json;charset=utf-8', 'application/json; charset=ISO-8859-1', False),
+    ('application/hal+json,application/json', 'application/xml', False),
+    ('application/hal+json,application/json', 'application/hal+xml; charset=utf-8', False),
+    ('application/vnd.custom.format', 'application/vnd.custom.format', True),
+    ('application/vnd.custom.format+json', 'application/vnd.custom.format+json; charset=ISO-8859-1', True),
+    ('application/vnd.custom.format+json', 'application/vnd.custom.format+xml', False),
+    ('application/vnd.custom.format+json, application/hal+json, application/json', 'application/json', True),
+    # optimistically accept content_type with additional parameter
+    ('application/vnd.custom.format+json, application/hal+json, application/json', 'application/hal+json; charset=utf-8', True),
+    ('application/vnd.custom.format+json, application/hal+json; charset=utf-8, application/json; charset=utf-8', 'application/vnd.custom.format+json', True),
+    # optimistically accept content_type with missing parameter
+    ('application/vnd.custom.format+json, application/hal+json; charset=utf-8, application/json; charset=utf-8', 'application/json', True),
+    ('application/vnd.custom.format+json, application/hal+json; charset=utf-8, application/json; charset=utf-8', 'application/json; charset=ISO-8859-1', False),
+    ('application/vnd.custom.format+json, application/hal+json, application/json', 'text/hal+json', False),
+    ('application/vnd.custom.format+json, application/hal+json, application/json', 'application/vnd.custom.format+xml', False)
+])
+def test_HALNavigator__can_parse(accept, content_type, can_parse):
+    index_uri = 'http://www.example.com/'
+    custom_headers = {'Accept': accept}
+    N = HN.Navigator.hal(index_uri, headers=custom_headers)
+    assert (N._can_parse(content_type) == can_parse)
+
+
 @pytest.fixture
 def bigtest_1():
     bigtest = type(str('bigtest_1'), (object,), {})

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -54,6 +54,16 @@ def test_normalize_getitem_args():
             == ['gax', ('foo', 'bar'), 0, 'baz', 1])
 
 
+def test_parse_media_type():
+    parse = RNU.parse_media_type
+    assert parse('foo') == ('foo', None, None)
+    assert parse('foo/bar') == ('foo', 'bar', None)
+    assert parse('foo/bar+baz') == ('foo', 'bar+baz', None)
+    assert parse('foo/bar+baz; param=foo') == ('foo', 'bar+baz', 'param=foo')
+    assert parse('foo/bar+baz; param=foo, param=bar') == ('foo', 'bar+baz', 'param=foo, param=bar')
+    assert parse('  foo/bar+baz ; param=foo  ') == ('foo', 'bar+baz', 'param=foo') 
+    
+
 @pytest.mark.parametrize(('root_uri', 'expected'), [
     ('http://www.example.com', 'Example'),
     ('www.example.com', 'Example'),


### PR DESCRIPTION
Proposed implementation for enahncement #20

Matched received content-type against 'accept' headers, making it possible to take account of custom content-types.
Performs optimistic matching with respect to media-type parameter options.
Included updated unit tests.
