### PR TITLE
Handle server error response with no content.

### DIFF
--- a/restnavigator/halnav.py
+++ b/restnavigator/halnav.py
@@ -505,7 +505,9 @@ class HALNavigatorBase(object):
         JSON
         '''
         self.response = response
-        if self._can_parse(response.headers['Content-Type']):
+        if int(response.headers.get('Content-Length', 0)) == 0:
+            hal_json = {}        
+        elif self._can_parse(response.headers['Content-Type']):
             hal_json = self._parse_content(response.text)
         else:
             raise exc.HALNavigatorError(


### PR DESCRIPTION
A server error response (e.g. 500 internal server error) with no content and no Content-Type causes an "Unexpected Content Type" HALNavigator exception.

Instead, allow ingesting the empty response and subsequently raise an appropriate exception in the _request method.
