### PR TITLE
Clarified how to test, added support for multiple links with the same uri.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -575,6 +575,7 @@ To run tests, execute following from the root of the source directory:
 
 ::
 
+    $ pip install -e .
     $ py.test
 
 Planned for the future


### PR DESCRIPTION
It can be the case that the same uri is used for several Link objects. For instance when deprecating a CURIE you might want to, temporarily, have the same uri twice, the old one and the new CURIE.

Caching on Link.uri will then not work. Caching on property would work however since you can add a deprecation property on one of the Link's.
