### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -607,6 +607,6 @@ Thanks very much to rest navigator's contributors:
 .. |Documentation Status| image:: https://readthedocs.org/projects/rest-navigator/badge/?version=latest
    :target: https://readthedocs.org/projects/rest-navigator/?badge=latest
    :alt: Documentation Status
-.. |Pypi Status| image:: https://pypip.in/v/restnavigator/badge.png
+.. |Pypi Status| image:: https://img.shields.io/pypi/v/restnavigator.svg
    :target: https://crate.io/packages/restnavigator/
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20restnavigator))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `restnavigator`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.